### PR TITLE
Replace deprecated 'bgl' module with 'gpu' module for Blender 4.x compatibility

### DIFF
--- a/JD_Miter_Box_forked/__init__.py
+++ b/JD_Miter_Box_forked/__init__.py
@@ -11,16 +11,22 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+import bpy
+from .addon.utility import addon
+
 bl_info = {
-    "name" : "Miter Box",
-    "author" : "João Desager",
+    "name" : "Miter Box (Forked)",
+    "author" : "João Desager / (Shibazo)",
     "description" : "Collection of Mesh Editing tools",
     "blender" : (3, 3, 4),
-    "version" : (0, 0, 5),
+    "version" : (0, 0, 6),
     "location" : "Edit Mode > Context Menu > MiterBox, N Panel > MB",
     "warning" : "",
-    "category" : "Generic"
+    "category" : "Generic",
+    "tagline" : "Forked and updated for Blender 4.x"
 }
+
+addon.addon_name = __name__
 
 def register():
     from .addon.register import register_addon

--- a/JD_Miter_Box_forked/addon/operator/align.py
+++ b/JD_Miter_Box_forked/addon/operator/align.py
@@ -18,6 +18,7 @@ from mathutils.geometry import intersect_line_line
 
 from ..utility.mesh import vert_pair_other_vert, coor_loc_to_world, coors_loc_to_world
 
+from ..utility.shader_utils import get_builtin_shader
 
 Align_kb_general = {'mode' :
     {'key':'V', 'desc':"Mode", 'var':'mode'},
@@ -421,7 +422,7 @@ class MB_OT_ALIGN(Operator):
         coors = [vert.co for vert in self.edge_active]
         world_coors = coors_loc_to_world(coors, self.obj)
 
-        shader = gpu.shader.from_builtin('3D_UNIFORM_COLOR')
+        shader = gpu.shader.from_builtin(get_builtin_shader())
         batch = batch_for_shader(shader, 'LINES', {"pos": world_coors})
 
         shader.bind()
@@ -436,7 +437,7 @@ class MB_OT_ALIGN(Operator):
         coors = [vert.co for vert in self.edge_selected]
         world_coors = coors_loc_to_world(coors, self.obj)
 
-        shader_active = gpu.shader.from_builtin('3D_UNIFORM_COLOR')
+        shader_active = gpu.shader.from_builtin(get_builtin_shader())
         batch_active = batch_for_shader(shader_active, 'LINES', {"pos": world_coors})
 
         shader_active.bind()
@@ -451,7 +452,7 @@ class MB_OT_ALIGN(Operator):
 
         world_coors = coor_loc_to_world(self.closest_active_vert.co, self.obj)
 
-        shader_dots = gpu.shader.from_builtin('3D_UNIFORM_COLOR')
+        shader_dots = gpu.shader.from_builtin(get_builtin_shader())
         batch_dots = batch_for_shader(shader_dots, 'POINTS', {"pos": [world_coors]})
 
         shader_dots.bind()
@@ -468,7 +469,7 @@ class MB_OT_ALIGN(Operator):
             world_coors = coors_loc_to_world(self.moving_lines, self.obj)
 
 
-            shader_moving_lines = gpu.shader.from_builtin('3D_UNIFORM_COLOR')
+            shader_moving_lines = gpu.shader.from_builtin(get_builtin_shader())
             batch_moving_lines = batch_for_shader(shader_moving_lines, 'LINES', {"pos": world_coors})
 
             shader_moving_lines.bind()
@@ -483,7 +484,7 @@ class MB_OT_ALIGN(Operator):
 
             world_coors = coors_loc_to_world(self.guide_edge, self.obj)
 
-            shader_moving_lines = gpu.shader.from_builtin('3D_UNIFORM_COLOR')
+            shader_moving_lines = gpu.shader.from_builtin(get_builtin_shader())
             batch_moving_lines = batch_for_shader(shader_moving_lines, 'LINES', {"pos": world_coors})
 
             shader_moving_lines.bind()
@@ -500,7 +501,7 @@ class MB_OT_ALIGN(Operator):
 
             world_coors = coors_loc_to_world(self.new_edge, self.obj)
 
-            shader_moving_lines = gpu.shader.from_builtin('3D_UNIFORM_COLOR')
+            shader_moving_lines = gpu.shader.from_builtin(get_builtin_shader())
             batch_moving_lines = batch_for_shader(shader_moving_lines, 'LINES', {"pos": world_coors})
 
             shader_moving_lines.bind()
@@ -515,7 +516,7 @@ class MB_OT_ALIGN(Operator):
 
             gpu.state.point_size_set(10)
 
-            shader_dots = gpu.shader.from_builtin('3D_UNIFORM_COLOR')
+            shader_dots = gpu.shader.from_builtin(get_builtin_shader())
             batch_dots = batch_for_shader(shader_dots, 'POINTS', {"pos": [world_coors]})
 
             shader_dots.bind()

--- a/JD_Miter_Box_forked/addon/operator/align_f/_op.py
+++ b/JD_Miter_Box_forked/addon/operator/align_f/_op.py
@@ -33,6 +33,7 @@ from ...utility.drawing.view import mouse_2d_to_3d
 from ...utility.drawing.tool_tip import build_tooltips
 from ...utility.jdraw.core import JDraw_Text_Box_Multi, JDraw_Text
 
+from ...utility.shader_utils import get_builtin_shader
 
 theme = bpy.context.preferences.themes[0]
 B_ui = theme.user_interface
@@ -606,7 +607,7 @@ class MB_OT_ALIGN_FACE(Operator):
         coors = [v.co for v in self.rot_edge]
         world_coors = coors_loc_to_world(coors, self.obj)
 
-        shader_moving_lines = gpu.shader.from_builtin('3D_UNIFORM_COLOR')
+        shader_moving_lines = gpu.shader.from_builtin(get_builtin_shader())
         batch_moving_lines = batch_for_shader(shader_moving_lines, 'LINES', {"pos": world_coors})
 
         shader_moving_lines.bind()
@@ -680,6 +681,7 @@ class MB_OT_ALIGN_FACE(Operator):
 
         textbox = JDraw_Text_Box_Multi(x=self.mouse_loc[0]+15, y=self.mouse_loc[1]-15, strings=texts, size=15)
         textbox.draw()
+        boxheight = abs(textbox.box.height)
 
         tool_header = JDraw_Text(x=self.mouse_loc[0]+20, y=self.mouse_loc[1]+0, string="Align Face", size=18)
         tool_header.draw()
@@ -692,10 +694,12 @@ class MB_OT_ALIGN_FACE(Operator):
 
         # texts.append("")
 
-        textbox = JDraw_Text_Box_Multi(x=self.mouse_loc[0]+15, y=self.mouse_loc[1]-230, strings=texts, size=12)
+        # textbox = JDraw_Text_Box_Multi(x=self.mouse_loc[0]+15, y=self.mouse_loc[1]-230, strings=texts, size=12)
+        textbox = JDraw_Text_Box_Multi(x=self.mouse_loc[0]+15, y=self.mouse_loc[1]-boxheight-15-30, strings=texts, size=12)
         textbox.draw()
 
-        tool_header = JDraw_Text(x=self.mouse_loc[0]+20, y=self.mouse_loc[1]-220, string="angle quick adjust", size=13)
+        # tool_header = JDraw_Text(x=self.mouse_loc[0]+20, y=self.mouse_loc[1]-220, string="angle quick adjust", size=13)
+        tool_header = JDraw_Text(x=self.mouse_loc[0]+20, y=self.mouse_loc[1]-boxheight-15-20, string="angle quick adjust", size=13)
         tool_header.draw()
 
         # --------------------------------------------------

--- a/JD_Miter_Box_forked/addon/utility/addon.py
+++ b/JD_Miter_Box_forked/addon/utility/addon.py
@@ -1,7 +1,7 @@
 import bpy
 
 
-addon_name = __name__.partition('.')[0]
+addon_name = None
 
 
 def get_prefs():

--- a/JD_Miter_Box_forked/addon/utility/drawing/primitives.py
+++ b/JD_Miter_Box_forked/addon/utility/drawing/primitives.py
@@ -7,6 +7,7 @@ from mathutils import Vector
 
 from ..math import rotate_to_space, rotate_point_around_axis
 
+from ..shader_utils import get_builtin_shader, get_builtin_shader_2d
 
 def plane_center(location, axis_x, axis_y, axis_z, size_x, size_y, color):
     # TRIS
@@ -27,7 +28,7 @@ def plane_center(location, axis_x, axis_y, axis_z, size_x, size_y, color):
     for vec in positions:
         vec += location
 
-    shader = gpu.shader.from_builtin('3D_UNIFORM_COLOR')
+    shader = gpu.shader.from_builtin(get_builtin_shader())
     batch = batch_for_shader(shader, 'TRIS', {"pos": positions}, indices=indices)
 
     shader.bind()
@@ -49,7 +50,7 @@ def line(location, axis_x, axis_y, axis_z, length, thickness, color):
         for vec in world_coors:
             vec += location
 
-        shader_moving_lines = gpu.shader.from_builtin('3D_UNIFORM_COLOR')
+        shader_moving_lines = gpu.shader.from_builtin(get_builtin_shader())
         batch_moving_lines = batch_for_shader(shader_moving_lines, 'LINES', {"pos": world_coors})
 
         shader_moving_lines.bind()
@@ -65,7 +66,7 @@ def line_p2p(start, end, thickness, color):
 
     coors = [start, end]
 
-    shader_line = gpu.shader.from_builtin('3D_UNIFORM_COLOR')
+    shader_line = gpu.shader.from_builtin(get_builtin_shader())
     batch_line = batch_for_shader(shader_line, 'LINES', {"pos": coors})
 
     shader_line.bind()
@@ -80,7 +81,7 @@ def lines_p2p(coor_pairs, thickness, color):
 # LINES
     gpu.state.line_width_set(thickness)
 
-    shader_line = gpu.shader.from_builtin('3D_UNIFORM_COLOR')
+    shader_line = gpu.shader.from_builtin(get_builtin_shader())
     batch_line = batch_for_shader(shader_line, 'LINES', {"pos": coor_pairs})
 
     shader_line.bind()
@@ -97,7 +98,7 @@ def line_2d(start, end, thickness, color):
 
         world_coors = [start, end]
 
-        shader_line = gpu.shader.from_builtin('2D_UNIFORM_COLOR')
+        shader_line = gpu.shader.from_builtin(get_builtin_shader_2d())
         batch_line = batch_for_shader(shader_line, 'LINES', {"pos": world_coors})
 
         shader_line.bind()
@@ -111,7 +112,7 @@ def edges(locations, thickness, color):
 
     gpu.state.line_width_set(thickness)
 
-    shader_moving_lines = gpu.shader.from_builtin('3D_UNIFORM_COLOR')
+    shader_moving_lines = gpu.shader.from_builtin(get_builtin_shader())
     batch_moving_lines = batch_for_shader(shader_moving_lines, 'LINES', {"pos": locations})
 
     shader_moving_lines.bind()
@@ -125,7 +126,7 @@ def points(locations, size, color):
 
     gpu.state.point_size_set(size)
 
-    shader_dots = gpu.shader.from_builtin('3D_UNIFORM_COLOR')
+    shader_dots = gpu.shader.from_builtin(get_builtin_shader())
     batch_dots = batch_for_shader(shader_dots, 'POINTS', {"pos": locations})
 
     shader_dots.bind()
@@ -157,7 +158,7 @@ def arc(center, axis_x, axis_y, axis_z, radius, angle, thickness, color):
         for vec in world_coors:
             vec += center
 
-        shader_arc = gpu.shader.from_builtin('3D_UNIFORM_COLOR')
+        shader_arc = gpu.shader.from_builtin(get_builtin_shader())
         batch_arc = batch_for_shader(shader_arc, 'LINE_STRIP', {"pos": world_coors})
 
         shader_arc.bind()

--- a/JD_Miter_Box_forked/addon/utility/jdraw/core.py
+++ b/JD_Miter_Box_forked/addon/utility/jdraw/core.py
@@ -1,5 +1,4 @@
 import bpy, blf, gpu
-from bgl import *
 from gpu_extras.batch import batch_for_shader
 
 from .helper import make_vertices, draw_quad
@@ -70,7 +69,13 @@ class JDraw_Text(JDraw_UI):
 
     # from ST3 course part 5-8
     def draw(self):
-        blf.size(self.font, self.fontsize, int(self.dpi))
+        major, minor, _ = bpy.app.version
+        if (major, minor) < (4, 0):
+            blf.size(self.font, self.fontsize, int(self.dpi))
+        else:
+            blf.size(self.font, self.fontsize)
+            # DPI 補正係数（経験的に調整）
+
         blf.color(self.font, *self.color)
         blf.position(self.font, self.x, self.y, 0)
 
@@ -89,8 +94,11 @@ class JDraw_Text(JDraw_UI):
     @property #getter
     def size(self):
         '''Return the dimensions of the string'''
-
-        blf.size(0, self.fontsize, self.dpi)
+        major, minor, _ = bpy.app.version
+        if (major, minor) < (4, 0):
+            blf.size(0, self.fontsize, self.dpi)
+        else:
+            blf.size(0, self.fontsize)
         return blf.dimensions(0, str(self.string))
 
 

--- a/JD_Miter_Box_forked/addon/utility/jdraw/helper.py
+++ b/JD_Miter_Box_forked/addon/utility/jdraw/helper.py
@@ -1,7 +1,7 @@
 import bpy, blf, gpu
-from bgl import *
 from gpu_extras.batch import batch_for_shader
 
+from ..shader_utils import get_builtin_shader, get_builtin_shader_2d
 
 # --- PRIMITIVE DRAWING
 
@@ -34,13 +34,13 @@ def draw_quad(vertices=[], color=(1,1,1,1)):
     '''Vertices = Top Left, Bottom Left, Top Right, Bottom Right'''
 
     indices = [(0, 1, 2), (1, 2, 3)]
-    shader = gpu.shader.from_builtin('2D_UNIFORM_COLOR')
+    shader = gpu.shader.from_builtin(get_builtin_shader_2d())
     batch = batch_for_shader(shader, 'TRIS', {"pos": vertices}, indices=indices)
     shader.bind()
     shader.uniform_float("color", color)
-    glEnable(GL_BLEND)
+    gpu.state.blend_set("ALPHA")
     batch.draw(shader)
-    glDisable(GL_BLEND)
+    gpu.state.blend_set("NONE")
 
     del shader
     del batch

--- a/JD_Miter_Box_forked/addon/utility/shader_utils.py
+++ b/JD_Miter_Box_forked/addon/utility/shader_utils.py
@@ -1,0 +1,29 @@
+import bpy
+
+def get_builtin_shader():
+    major, minor, patch = bpy.app.version
+
+    if (major, minor) == (3, 3):
+        return '3D_UNIFORM_COLOR'
+    elif (major, minor) >= (3, 4):
+        return 'UNIFORM_COLOR'
+    elif (major, minor) >= (4, 0) and  (major, minor) < (4, 5):
+        return 'UNIFORM_COLOR'
+    elif (major, minor) >= (4, 5):
+        return 'POLYLINE_UNIFORM_COLOR'
+    else:
+        return 'DEFAULT_SHADER'  # フォールバック
+
+def get_builtin_shader_2d():
+    major, minor, patch = bpy.app.version
+
+    if (major, minor) == (3, 3):
+        return '2D_UNIFORM_COLOR'
+    elif (major, minor) >= (3, 4):
+        return 'UNIFORM_COLOR'
+    elif (major, minor) >= (4, 0) and  (major, minor) < (4, 5):
+        return 'UNIFORM_COLOR'
+    elif (major, minor) >= (4, 5):
+        return 'POLYLINE_UNIFORM_COLOR'
+    else:
+        return 'DEFAULT_SHADER'  # フォールバック

--- a/JD_Miter_Box_forked/blender_manifest.toml
+++ b/JD_Miter_Box_forked/blender_manifest.toml
@@ -1,0 +1,10 @@
+schema_version = "1.0.0"
+id = "jd_miter_box_forked"
+name = "Miter Box (Forked)"
+version = "0.0.6"
+tagline = "Forked and updated for Blender 4.x"
+maintainer = "João Desager / (Shibazo)"
+type = "add-on"
+blender_version_min = "3.3.4"
+license = ["SPDX:GPL-3.0-or-later"]
+website = "https://github.com/shibazo/JD-Miter-Box-Forked"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+# Miter Box Fork
+This is a fork of Miter Box.<br />
+The Original addon is here:<br />
+https://github.com/JohnKazucki/JD-Miter-Box<br />
+
+# Abount change from original addon<br />
+Updated use GPU module instead of BGL module.<br /><br /><br />
+
 # Miter Box
 
 MB is a set of tools designed to make accurate polymodelling quicker and easier. <br />


### PR DESCRIPTION
Updateed for Blender 4.x.